### PR TITLE
Adjusted IndexModel to extend DefaultTableModel

### DIFF
--- a/src/main/java/com/picklez/IndexModel.java
+++ b/src/main/java/com/picklez/IndexModel.java
@@ -8,7 +8,10 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class IndexModel implements Serializable
+import javax.swing.table.DefaultTableModel;
+
+// Class now extends DefaultTableModel as originally designed
+public class IndexModel extends DefaultTableModel implements Serializable
 {
 
     @SerializedName("Team Name")
@@ -27,6 +30,7 @@ public class IndexModel implements Serializable
     private final static long serialVersionUID = -5893562234839116493L;
     private final static String filePath = System.getProperty("user.home") + "\\index.json";
     private final static Gson gson = new GsonBuilder()
+            .excludeFieldsWithoutExposeAnnotation() // Ensure only desired fields are persisted
             .setPrettyPrinting()
             .serializeNulls()
             .create();
@@ -37,14 +41,17 @@ public class IndexModel implements Serializable
      *
      */
     public IndexModel() {
+        // Table settings moved from SearchEngineMaintenance
+        addColumn("File Name");
+        addColumn("Status");
     }
 
     /**
      *
-     * @param teamName
-     * @param fileList
-     * @param version
-     * @param indexUID
+     * @param teamName Name of the team that created this application
+     * @param fileList List of files that are contained in the Index
+     * @param version Current version number of the application
+     * @param indexUID Unique ID for files in the Index
      */
     public IndexModel(String teamName, float version, int indexUID, List<FileItem> fileList) {
         super();
@@ -55,7 +62,7 @@ public class IndexModel implements Serializable
     }
 
     public static IndexModel getModel() throws IOException {
-        File file = new File(System.getProperty("user.home") , "\\index.json");
+        File file = new File(filePath);  // Replaced hardcoded value
 
         if (!file.isFile() && !file.createNewFile())
         {
@@ -131,5 +138,12 @@ public class IndexModel implements Serializable
         //Refreshes the words on the list
         //Has to determine the last time updated and compare to current time
         //https://mkyong.com/java/how-to-get-the-file-last-modified-date-in-java/
+    }
+
+    // Moved from SearchEngineMaintenance
+    @Override
+    public boolean isCellEditable(int row, int column) {
+        // All cells false
+        return false;
     }
 }

--- a/src/main/java/com/picklez/SearchEngineMaintenance.java
+++ b/src/main/java/com/picklez/SearchEngineMaintenance.java
@@ -1,7 +1,6 @@
 package com.picklez;
 
 import javax.swing.*;
-import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -46,19 +45,6 @@ public class SearchEngineMaintenance extends JFrame {
         setVisible(true);
 
         // Set up table model and add to table
-        DefaultTableModel tableModel = new DefaultTableModel(){
-
-            @Override
-            public boolean isCellEditable(int row, int column) {
-                // All cells false
-                return false;
-            }
-
-        };
-
-        indexTable.setModel(tableModel);
-        tableModel.addColumn("File Name");
-        tableModel.addColumn("Status");
         try {
             model = IndexModel.getModel();
         } catch (IOException e) {
@@ -69,6 +55,8 @@ public class SearchEngineMaintenance extends JFrame {
             model.setVersion(1);
         }
 
+        indexTable.setModel(model);
+
         // Add files to the table on this form
         addFileButton.addActionListener(e -> {
             FileDialog fd = new FileDialog((Dialog) null, "Select file", FileDialog.LOAD);
@@ -76,7 +64,7 @@ public class SearchEngineMaintenance extends JFrame {
             String filePath = fd.getDirectory() + fd.getFile();
             //Creates a file object from the FileDialog to be able to process
             File file = new File(fd.getDirectory() + fd.getFile());
-            tableModel.insertRow(0, new String[]{filePath, "Not indexed"});
+            model.insertRow(0, new String[]{filePath, "Not indexed"});
             fileHandler(file);
             IndexModel.saveIndex(model);
 
@@ -84,7 +72,7 @@ public class SearchEngineMaintenance extends JFrame {
         });
 
         // Remove the selected row from the table
-        removeSelectedFilesButton.addActionListener(e -> tableModel.removeRow(indexTable.getSelectedRow()));
+        removeSelectedFilesButton.addActionListener(e -> model.removeRow(indexTable.getSelectedRow()));
     }
     public void fileHandler(File fd ) {
         //Read data for file to add to the File Item and indexModel


### PR DESCRIPTION
Adding line 33 to IndexModel.java allows us to take advantage of @Expose annotations and prevents multiple issues with GSON serialization and unwanted persistent data.

As a result I moved a few lines from SearchEngineMaintenance.java that pertained to a TableModel to the updated IndexModel.java.